### PR TITLE
Add cloud-config.yaml for multipass launch --cloud-init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 # ignore relativepath ssh key files
-relativepath
-relativepath.pub
+
+id_ed25519*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # ignore relativepath ssh key files
 
 id_ed25519*
+cloud-init.yaml

--- a/cloud-config.yaml
+++ b/cloud-config.yaml
@@ -1,0 +1,5 @@
+# cloud-config
+users:
+  - name: sanlung
+    ssh-authorized-keys:
+      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExiDWVqLt7CevJbSFHqYHzNd0p9AvrLdVwV8I+VAlHY sanlung@ChungMacB.local

--- a/cloud-config.yaml
+++ b/cloud-config.yaml
@@ -1,5 +1,0 @@
-# cloud-config
-users:
-  - name: sanlung
-    ssh-authorized-keys:
-      - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExiDWVqLt7CevJbSFHqYHzNd0p9AvrLdVwV8I+VAlHY sanlung@ChungMacB.local

--- a/webserver.sh
+++ b/webserver.sh
@@ -44,20 +44,22 @@ else
   ssh-keygen -t ed25519 -f "./id_ed25519" -N ''
 fi
 
-# checking for cloud-config.yaml
-if [ -f "./cloud-config.yaml" ]
+# checking for cloud-init.yaml
+if [ -f "./cloud-init.yaml" ]
 then
-  echo "cloud-config.yaml file already exists"
-else
-  echo "cloud-config.yaml file does not exist ... creating"
-  cat <<- _EOF_ > ./cloud-config.yaml
-	# cloud-config
-	users:
-	  - name: $USER
-	    ssh-authorized-keys:
-	      - $(cat ./id_ed25519.pub)
-	_EOF_
+  echo "cloud-init.yaml file already exists...deleting"
+  rm ./cloud-init.yaml
 fi
+
+# creating cloud-init.yaml
+echo "cloud-init.yaml file does not exist ... creating"
+cat <<- _EOF_ > ./cloud-init.yaml
+# cloud-config
+users:
+  - name: $USER
+    ssh-authorized-keys:
+      - $(cat ./id_ed25519.pub)
+_EOF_
 
 # spinning up a ubuntu vm
 if ( multipass list | grep "relativepath" )
@@ -65,7 +67,7 @@ then
   echo "relativepath vm is running"
 else 
   echo "launching a ubuntu vm named relativepath"
-  multipass launch --name relativepath --cloud-init cloud-config.yaml
+  multipass launch --name relativepath --cloud-init cloud-init.yaml
 fi
 
 # lookup ip address of relativepath vm

--- a/webserver.sh
+++ b/webserver.sh
@@ -53,7 +53,7 @@ else
   cat <<- _EOF_ > ./cloud-config.yaml
 	# cloud-config
 	users:
-	  - name: $(whoami)
+	  - name: $USER
 	    ssh-authorized-keys:
 	      - $(cat ./id_ed25519.pub)
 	_EOF_
@@ -72,4 +72,4 @@ fi
 RELATIVEPATH_IP=$( multipass info relativepath | grep IPv4 | tr -s ' ' | cut -d ' ' -f 2 )
 
 # ssh to relativepath vm
-ssh -i ./id_ed25519 $(whoami)@$RELATIVEPATH_IP
+ssh -i ./id_ed25519 $USER@$RELATIVEPATH_IP


### PR DESCRIPTION
 though of adding in the `webserver.sh` file a script that creates a universal `cloud-config.yaml` file, which can then be specified in the `--cloud-init` option when launching the vm `relativepath`. Upon executing `bash ./webserver.sh`, the script runs successfully to create the `cloud-config.yaml` file, as evidenced by the following screenshot:

![05-19-23_relativepath](https://github.com/slashrelativepath/relativepath-cycle-3/assets/58524911/03028769-be3a-418e-a4dd-ca80e742f46d)

However, the execution stops short at failing to launch the vm instance, flagging:
```
launch failed: The following errors occurred
Instance stopped while starting
ssh: Could not resolve hostname --: nodename nor servname provided, or not known
```
This seems not to do with the content of the `webserver.sh` file, but rather a failure of multipass to connect to some external source in launching the vm--as the instance was never created to continue to the ssh connection to it.

Could anyone help here by pulling this branch down to the local repo and run the `webserver.sh` file to see if the added script works on their machine or not?

For those who might not know how, here's how to pull this branch down to your local repo:
At your `main` branch,
```
$ git fetch origin
$ git checkout -b chung/take-it-to-the-finish-line origin/chung/take-it-to-the-finish-line
```
Thanks for helping.